### PR TITLE
install own uuid and promise lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict';
 
 var wrappers = require('pouchdb-wrappers');
+var uuid = require('node-uuid').v4;
+var Promise = require('es6-promise').Promise;
 
 exports.enableUndo = function (options) {
 	if (!options) { options = {}; }
 	if (!options.hasOwnProperty('limit')) { options.limit = 100; }
 	var db = this,
 		PouchDB = this.constructor,
-		Promise = PouchDB.utils.Promise,
-		uuid = PouchDB.utils.uuid,
 		error = function (options) {
 			var error = new Error(options.reason);
 			error.status = options.status;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "underscore": "^1.8.3"
   },
   "dependencies": {
+    "es6-promise": "^3.2.1",
+    "node-uuid": "^1.4.7",
     "pouchdb-wrappers": "^1.3.6"
   }
 }


### PR DESCRIPTION
as discussed here: https://github.com/FlamingTempura/pouchdb-undo/issues/1

I decided against using [pouchdb-utils](https://www.npmjs.com/package/pouchdb-utils) since it contains a lot of stuff we do not need and I'm not sure how to handle peerDependencies/externals with browserify.

node-uuid points to this ["crazy shit"](https://gist.github.com/jed/982883) if we want to go all in on micro-optimisation, but we'd need to check that in, which I don't like.
